### PR TITLE
specify custom getMeta() function

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "mocha": "~1.20.1",
     "nock": "^0.43.0",
     "request": "^2.49.0",
-    "uglify-js": "~2.4.15"
+    "uglify-js": "~2.4.15",
+    "underscore": "^1.8.3"
   },
   "keywords": [
     "biojs",

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -3,6 +3,8 @@ st = require "msa-seqtools"
 
 module.exports = Fasta =
 
+  getMeta: st.getMeta
+  
   parse: (text) ->
     seqs = []
 
@@ -12,20 +14,19 @@ module.exports = Fasta =
 
     text = text.split("\n") unless Object::toString.call(text) is '[object Array]'
 
+    getMeta = this.getMeta
+
     for line in text
       # check for header
       if line[0] is ">" or line[0] is ";"
 
         label = line[1..]
         # extract IDs and push them to the meta dict
-        obj = st.getMeta(label)
+        obj = getMeta(label)
         label = obj.name
-
-        currentSeq = new st.model("", label, seqs.length)
+        id = obj.id || seqs.length
+        currentSeq = new st.model( "", obj.name, id )
         currentSeq.ids = obj.ids || {}
-        keys = Object.keys currentSeq.ids
-        if keys.length > 0
-          currentSeq.id = currentSeq.ids[keys[0]]
         currentSeq.details = obj.details || {}
         seqs.push currentSeq
       else

--- a/test/fasta.js
+++ b/test/fasta.js
@@ -4,6 +4,7 @@ var fs = require('fs')
 var Fasta = require('../')
 
 require('mocha')
+var _ = require("underscore")
 var assert = require("assert")
 var nock = require('nock')
 var request = require("request");
@@ -32,10 +33,76 @@ test("test parsing of a file with fs", function(done) {
       return console.log(err);
     }
     var seqs = Fasta.parse(data);
+    var firstseq = seqs[0];
     assert.equal(13, seqs.length, "wrong seq number");
     assert.equal(seqs[0].seq.substring(0, 60), "MASLITTKAMMSHHHVLSSTRITTLYSDNSIGDQQIKTKPQVPHRLFARRIFGVTRAVIN");
-    assert.equal(seqs[12].seq, "MKTLLLTLVVVTIVYLDLGYTTKCYNHQSTTPETTEICPDSGYFCYKSSWIDGREGRIERGCTFTCPELTPNGKYVYCCRRDKCNQ");
+    assert.equal(seqs[12].seq, "MKTLLLTLVVVTIVYLDLGYTTKCYNHQSTTPETTEICPDSGYFCYKSSWIDGREGRIERGCTFTCPELTPNGKYVYCCRRDKCNQ");    
     done();
   })
+});
 
+test("testing a custom getMeta function", function(done) {
+
+  // get meta information from a completely different format
+  var data = "\
+>database|v1.2|1abcA01 GO=GO:012345,GO:023456;EC=1.2.3.4\n\
+MKTLLLTLVVVTIVYLDLGYTTKCYNHQSTTPETTEICPDSGYFCYKSSWIDGREGRIERGCTFTCPELTPNGKYVYCCRRDKCN\n\
+>database|v1.2|1abcA02\n\
+-------LVVVTIVYLDLGYTTKCYNHQSTTPETTEICPDSGYFCYKSSWIDGREGRIERGCTFTCPEL----------------\n\
+";
+
+  var visit_counter = 0;
+  
+  var customGetMeta = function(header) {
+    
+    visit_counter++;
+        
+    var id, name, details = {}, ids = {};
+        
+    var parts = header.split(/\s+/);
+    var id_str = parts[0];
+    var details_str = parts[1];
+    
+    if ( id_str ) {
+      var id_parts = id_str.split( '|' );
+      db = id_parts[0];
+      db_version = id_parts[1];
+      id = id_parts[2];
+      ids[ db ] = db_version;
+      name = id;
+    }
+        
+    if ( details_str ) {
+      var details_parts = details_str.split( ';' );    
+      details_parts.forEach( function(detail_str) {
+        var detail_kv_parts = detail_str.split('=');
+        var key = detail_kv_parts[0];
+        var values = detail_kv_parts[1].split(',');
+        details[ key.toLowerCase() ] = values;
+      });
+    }
+    
+    return {
+      id: id,
+      name: name,
+      details: details, 
+      ids: ids
+    };
+  };
+
+  var altFasta = _.extend( {}, Fasta );
+  altFasta.getMeta = customGetMeta;
+  
+  var seqs = altFasta.parse(data);  
+  assert.equal(visit_counter, 2, "visited getMeta wrong number of times" );  
+  assert.equal(2, seqs.length, "wrong seq number");
+  var firstseq = seqs[0];
+    
+  assert.equal(firstseq.id, '1abcA01');
+  assert.equal(firstseq.seq, 'MKTLLLTLVVVTIVYLDLGYTTKCYNHQSTTPETTEICPDSGYFCYKSSWIDGREGRIERGCTFTCPELTPNGKYVYCCRRDKCN');
+  assert.deepEqual(firstseq.ids, { database: 'v1.2' } );
+  assert.deepEqual(firstseq.details, { go: [ 'GO:012345', 'GO:023456' ], ec: [ '1.2.3.4' ] } );
+  
+  done();
 })
+


### PR DESCRIPTION
In cases where FASTA headings have been formatted in weird and wonderful ways, it might be useful to make it easy to provide a custom meta data processor.

e.g. currently we process the header into the id, etc.

```
\\ msa-seqtools
getMeta( ">1abcA01|dbname|v1.2 long description GO=GO:012345 EC=1.2.3.4" )

{
    id: 1abcA01,
    name: "long description",
    ids: { dbname: v1.2 }
    details: {
        go: [ GO:012345, GO:023456 ],
        ec: [ 1.2.3.4 ]
    }
}
```

...but it would be useful to be able to parse a completely different format into
something sensible (without having to redo all the file parsing bits).

```
getMeta( ">dbname|v1.2|1abcA01 GO=GO:012345,GO:023456;EC=1.2.3.4" )

{
    id: 1abcA01,
    ids: { dbname: v1.2 },
    details: {
        go: [ GO:012345, GO:023456 ],
        ec: [ 1.2.3.4 ]
    }
}
```

Essentially:
1. store getMeta as a class attribute, 
2. extend Fasta -> myFasta
3. override the myFasta.getMeta function

see `test/simple.js`

**TODO: point 2 in the above list should probably be improved before this is implemented.** I wasn't sure whether it was better to provide a local .mixin or .extend function that would play nicely with the general inheritence hierarchy (currently it just uses `_.extend`)
