### PR TITLE
fix getMeta (this.getMeta -> Fasta.getMeta)

### DIFF
--- a/src/fasta.coffee
+++ b/src/fasta.coffee
@@ -19,7 +19,7 @@ module.exports = Fasta =
 
     text = text.split("\n") unless Object::toString.call(text) is '[object Array]'
 
-    getMeta = this.getMeta
+    getMeta = Fasta.getMeta
 
     for line in text
       # check for header


### PR DESCRIPTION
Fasta.getMeta is a class method so it shouldn't be using "this" (see Fasta.extend())
